### PR TITLE
Initial published version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
-# atom package
+language-factor
+===============
 
-This is a syntax highlighting package for Factor.
+This is a syntax highlighting package for [Factor language][factor].
 
-You can install this by copying this folder to:
+You can install it through the standard Atom UI: just search for
+`language-factor` in an available package list.
 
-  cp -r /path/to/factor/misc/atom ~/.atom/packages/language-factor
+This package have support for both Factor and Factor inclusions in HTML code.
+Select either `Factor` or `HTML )Factor)` syntax highlighting scheme in your
+editor tab. The corresponding scheme should be selected automatically on opening
+`.factor`, `.facts`, `.furnace` or `.fhtml` file.
 
-Or symlinking it:
-
-  ln -sf /path/to/factor/misc/atom ~/.atom/packages/language-factor
+History
+-------
 
 This was initially generated from the Textmate bundle:
 
-  apm init --package atom --convert Factor.tmbundle
+    apm init --package atom --convert Factor.tmbundle
+
+License
+-------
+
+This package is distributed under the terms of a [MIT License][mit-license].
+
+[factor]: https://factorcode.org/
+[mit-license]: https://opensource.org/licenses/MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-factor",
-  "version": "0.1.0",
+  "version": "0.1.1-0",
   "description": "Factor language support for Atom",
   "keywords": [
     "factor"
@@ -10,6 +10,5 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "atom",
-  "version": "0.0.0",
-  "description": "A short description of your package",
+  "name": "language-factor",
+  "version": "0.1.0",
+  "description": "Factor language support for Atom",
   "keywords": [
+    "factor"
   ],
-  "repository": "https://github.com/atom/atom",
+  "repository": "https://github.com/ForNeVeR/atom-language-factor",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "factor"
   ],
-  "repository": "https://github.com/ForNeVeR/atom-language-factor",
+  "repository": "https://github.com/factor/atom-language-factor",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"


### PR DESCRIPTION
Hello! I've taken the responsibility to publish the first package version there: https://atom.io/packages/language-factor

It may already be installed by our wonderful users :)

Please note that I've written about the MIT license in README file. Is it right? I've deduced the license from an already existing [package.json](https://github.com/factor/atom-language-factor/blob/master/package.json#L8) file, but that may just be a default stub and maybe you'll want to change it to something according to the general Factor guidelines.

I kindly request you to give me push rights for this repository, because this will let me publish Atom packages more easyly. `apm publish` process needs to check and commit some stuff in **this** repository (because we want URL of **this** repository to be mentioned as an official issue tracker etc.) as documented [here](https://github.com/atom/atom/blob/master/docs/apm-rest-api.md#post-apipackages), so the simplest way would be to just grant me the rights so I can maintain it without too much fuss.

I am ready to maintain this project in future, review any pull requests and generally keep it in a good form.

Currently `language-factor` have version `0.1.0-0` which counts as "prerelease" whatever that means for Atom. I have a plan to publish a "release" `0.1.0` after you give me the access rights, so I can replace the repository URL.
